### PR TITLE
Add iOS and Web Platform Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # capacitor-export-file
 
-A capacitor plugin to export file with Android SAF API
+A Capacitor plugin to export files using the Android SAF (Storage Access Framework) API and iOS UIDocumentPickerViewController.
 
-- Support capacitor v7.
-- Only support Android.
-- Written in kotlin, so you need to configure kotlin for your project before using it.
+- Supports Capacitor v7.
+- Works on Android, iOS & Web
+
+## Requirements
+
+* **Kotlin** must be configured in your Android project (required for Android support).
+* **iOS 16.0+** is required for the iOS implementation.
 
 ## Install
 
@@ -27,14 +31,14 @@ npx cap sync
 ### exportFile(...)
 
 ```typescript
-exportFile(options: { uri: string; filename?: string; }) => any
+exportFile(options: { uri: string; filename?: string; }) => Promise<{ uri: string; }>
 ```
 
 | Param         | Type                                             |
 | ------------- | ------------------------------------------------ |
 | **`options`** | <code>{ uri: string; filename?: string; }</code> |
 
-**Returns:** <code>any</code>
+**Returns:** <code>Promise&lt;{ uri: string; }&gt;</code>
 
 --------------------
 

--- a/ios/Sources/ExportFilePlugin/ExportFile.swift
+++ b/ios/Sources/ExportFilePlugin/ExportFile.swift
@@ -1,8 +1,5 @@
 import Foundation
 
 @objc public class ExportFile: NSObject {
-    @objc public func echo(_ value: String) -> String {
-        print(value)
-        return value
-    }
+
 }

--- a/ios/Sources/ExportFilePlugin/ExportFilePlugin.swift
+++ b/ios/Sources/ExportFilePlugin/ExportFilePlugin.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Capacitor
+import UniformTypeIdentifiers
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -10,14 +11,79 @@ public class ExportFilePlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "ExportFilePlugin"
     public let jsName = "ExportFile"
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "echo", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "exportFile", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = ExportFile()
 
-    @objc func echo(_ call: CAPPluginCall) {
-        let value = call.getString("value") ?? ""
-        call.resolve([
-            "value": implementation.echo(value)
+    // Store the pending call to resolve it later
+    private var exportCall: CAPPluginCall?
+
+    @objc func exportFile(_ call: CAPPluginCall) {
+        guard let uri = call.getString("uri") else {
+            call.reject("Must provide a URI")
+            return
+        }
+
+        // Get the file URL from the URI
+        guard let sourceURL = URL(string: uri) else {
+            call.reject("Invalid file URI")
+            return
+        }
+
+        // Check if the file exists
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            call.reject("File does not exist at given URI")
+            return
+        }
+
+        // Determine suggested filename
+        let suggestedFilename = call.getString("filename") ?? sourceURL.lastPathComponent
+
+        // Set up a temporary location with the correct file name
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempURL = tempDir.appendingPathComponent(suggestedFilename)
+
+        do {
+            // Copy to temp if needed (Document picker works best with temp or local files)
+            if sourceURL != tempURL {
+                try? FileManager.default.removeItem(at: tempURL)
+                try FileManager.default.copyItem(at: sourceURL, to: tempURL)
+            }
+
+            let documentPicker = UIDocumentPickerViewController(forExporting: [tempURL])
+            documentPicker.shouldShowFileExtensions = true
+            documentPicker.delegate = self
+            documentPicker.presentationController?.delegate = self
+
+            self.exportCall = call // Store call for later resolve
+
+            DispatchQueue.main.async {
+                self.bridge?.viewController?.present(documentPicker, animated: true, completion: nil)
+            }
+
+        } catch {
+            call.reject("Failed to prepare file for export: \(error.localizedDescription)")
+        }
+    }
+}
+
+extension ExportFilePlugin: UIDocumentPickerDelegate, UIAdaptivePresentationControllerDelegate {
+    public func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        exportCall?.reject("User cancelled export")
+        exportCall = nil
+    }
+
+    public func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let selectedURL = urls.first else {
+            exportCall?.reject("No file destination selected")
+            exportCall = nil
+            return
+        }
+
+        // Resolve the stored plugin call with the destination URI
+        exportCall?.resolve([
+            "uri": selectedURL.absoluteString
         ])
+        exportCall = nil
     }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -3,7 +3,30 @@ import { WebPlugin } from '@capacitor/core';
 import type { ExportFilePlugin } from './definitions';
 
 export class ExportFileWeb extends WebPlugin implements ExportFilePlugin {
-  async exportFile(): Promise<{ uri: string }> {
-    throw this.unimplemented('Only support Android');
+  async exportFile(options: { uri: string; filename?: string }): Promise<{ uri: string }> {
+    const { uri, filename = 'download_file' } = options;
+
+    try {
+      const response = await fetch(uri);
+      const blob = await response.blob();
+
+      const objectURL = URL.createObjectURL(blob);
+
+      const anchor = document.createElement('a');
+      anchor.href = objectURL;
+      anchor.download = filename;
+      anchor.style.display = 'none';
+
+      document.body.appendChild(anchor);
+      anchor.click();
+
+      // Clean up
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(objectURL);
+
+      return { uri: objectURL };
+    } catch (error) {
+      throw new Error(`Failed to export file: ${(error as Error).message}`);
+    }
   }
 }


### PR DESCRIPTION
###  Summary

This PR adds support for **iOS** and **Web** platforms to the existing Capacitor plugin, which previously supported only Android via the SAF API.

### What's Included

#### iOS

* Implements `exportFile` using `UIDocumentPickerViewController` for iOS 16.0+.
* Supports user interaction to choose destination and filename via the native save dialog.
* Returns the selected destination URI as `{ uri: "<file-url>" }`.

#### Web

* Adds a browser-compatible implementation using `fetch` and `Blob` to trigger a file download.
* Automatically creates an `<a>` tag and simulates user-initiated download behavior.
* Returns a blob URI as `{ uri: "<object-url>" }`.

### Notes

* iOS support requires a minimum deployment target of **iOS 16.0**.
* Android support remains unchanged (SAF API in Kotlin).
* Web support provides a non-native but functional download experience.
* The plugin now provides a consistent interface across **Android**, **iOS**, and **Web**.

### Testing

* iOS tested on real device (iOS 16+)
* Web tested in modern browsers (Chrome, Safari)
